### PR TITLE
Parse v.mod with a final newline correctly

### DIFF
--- a/api/vmod.v
+++ b/api/vmod.v
@@ -52,7 +52,7 @@ fn tokenize(t_type Lexeme, val string) Token {
 }
 
 fn (s mut VModScanner) skip_whitespace() {
-	for s.pos < s.text.len && s.text[s.pos].is_white() {
+	for s.pos < s.text.len-1 && s.text[s.pos].is_white() {
 		s.pos++
 	}
 }


### PR DESCRIPTION
When I run `vpkg` in a project directory where `v.mod` with a final newline is stored, I got a V panic:
```
$ vpkg
V panic: string index out of range: 69 / 69
14: v_panic                     C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:2213
13: string_at                   C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:4213
12: api__VModScanner_scan       C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:10535
11: api__VModScanner_parse      C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:10628
10: api__open_vmod              C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:10692
9 : api__load_manifest_file     C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:9666
8 : api__new                    C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:9382
7 : main__main                  C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:10697
6 : wmain                       C:\Users\esprit\AppData\Local\Temp\v\vpkg.tmp.c:10838
5 : invoke_main                 d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:91
4 : __scrt_common_main_seh      d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
3 : __scrt_common_main          d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331
2 : wmainCRTStartup             d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_wmain.cpp:17
1 : BaseThreadInitThunk         ?? : address= 0000002189FCD6C8
0 : RtlUserThreadStart          ?? : address= 0000002189FCD6D0
```
I fixed this issue by changing the condition of `for` loop in `VModScanner.skip_whitespace` function.

The max value for `s.pos` is `s.text.len-1`, so it should be **less than max value** before being incremented to avoid out of range errors.