### PR TITLE
Use `string.is_space` instead of `string.is_white`

### DIFF
--- a/api/vmod.v
+++ b/api/vmod.v
@@ -75,7 +75,7 @@ fn tokenize(t_type Lexeme, val string) Token {
 }
 
 fn (s mut VModScanner) skip_whitespace() {
-	for s.pos < s.text.len-1 && s.text[s.pos].is_white() {
+	for s.pos < s.text.len-1 && s.text[s.pos].is_space() {
 		s.pos++
 	}
 }


### PR DESCRIPTION
`string.is_white` is deprecated and replaced with `string.is_space`

Ref https://github.com/vlang/v/commit/c85ccad0a68ed9f2da523635c37b8296f7c92fd3.