### PR TITLE
Minor update which allows vpkg to compile and run with v0.2 of V

### DIFF
--- a/api/commands.v
+++ b/api/commands.v
@@ -2,6 +2,7 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
+// Copyright (C) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -130,7 +131,11 @@ pub fn (vpkg Vpkg) create_manifest_file() {
         return
     }
 
-    manifest_data.write(mw.contents.str())
+    manifest_data.write(mw.contents.str().bytes()) or {
+        eprintln(err)
+        println('Terminating...')
+        exit(0)
+    }
     defer { manifest_data.close() }
     mw.contents.free()
 
@@ -251,7 +256,11 @@ pub fn (vpkg Vpkg) unlink(dir string) {
     name := if !is_empty_str(vpkg.manifest.name) {vpkg.manifest.name} else {dirname(dir)}
     target := os.join_path(global_modules_dir, name)
     if os.exists(target) {
-        os.rm(os.join_path(global_modules_dir, name))
+        os.rm(os.join_path(global_modules_dir, name)) or {
+            eprintln(err)
+            println('Terminating...')
+            exit(0)
+        }
     }
     if !os.exists(target) {
         println('Successfully unlinked $name')

--- a/api/commands.v
+++ b/api/commands.v
@@ -2,7 +2,6 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
-// Copyright (C) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/api/fetch.v
+++ b/api/fetch.v
@@ -2,6 +2,7 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
+// Copyright (C) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,9 +27,9 @@ module api
 import os
 
 struct Package {
-    name   string = ''
-    url    string = ''
-    method string = ''
+    name   string
+    url    string
+    method string
 }
 
 struct InstalledPackage {

--- a/api/fetch.v
+++ b/api/fetch.v
@@ -2,7 +2,6 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
-// Copyright (C) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/api/lockfile.v
+++ b/api/lockfile.v
@@ -2,7 +2,6 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
-// Copyright (C) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/api/manifest.v
+++ b/api/manifest.v
@@ -2,6 +2,7 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
+// Copyright (c) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -199,7 +200,11 @@ fn migrate_manifest_file(dir string, manifest PkgManifest, format string) {
     }
 
     if m_path.ends_with('.vpkg.json') && format == 'vpkg' {
-        os.mv(m_path, os.join_path(dir, 'vpkg.json'))
+        os.mv(m_path, os.join_path(dir, 'vpkg.json')) or {
+            eprintln(err)
+            println('Terminating...')
+            exit(0)
+        }
     } 
 }
 
@@ -271,7 +276,11 @@ fn manifest_to_vmod(manifest PkgManifest, dir string) {
     mut vmod_file := os.create(os.join_path(dir, 'v.mod')) or { return }
     vmod_contents_str := manifest.to_vmod()
 
-    vmod_file.write(vmod_contents_str)
+    vmod_file.write(vmod_contents_str.bytes()) or {
+        eprintln(err)
+        println('Terminating...')
+        exit(0)
+    }
     defer { vmod_file.close() }
 }
 
@@ -279,6 +288,10 @@ fn manifest_to_vpkg(manifest PkgManifest, dir string) {
     mut vpkg_file := os.create(os.join_path(dir, 'vpkg.json')) or { return }
     vpkg_contents_str := manifest.to_vpkg_json()
 
-    vpkg_file.write(vpkg_contents_str)
+    vpkg_file.write(vpkg_contents_str.bytes()) or {
+        eprintln(err)
+        println('Terminating...')
+        exit(0)
+    }
     defer { vpkg_file.close() }
 }

--- a/api/manifest.v
+++ b/api/manifest.v
@@ -2,7 +2,6 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
-// Copyright (c) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/api/utils.v
+++ b/api/utils.v
@@ -2,6 +2,7 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
+// Copyright (c) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +28,11 @@ import os
 import net.urllib
 
 fn delete_content(path string) {
-    os.rm(path)
+    os.rm(path) or {
+        eprintln(err)
+        println('Terminating...')
+        exit(0)
+    }
 }
 
 fn delete_package_contents(path string) bool {
@@ -35,7 +40,11 @@ fn delete_package_contents(path string) bool {
     new_folder_contents := os.ls(path) or { return false }
 
     if new_folder_contents.len == 0 {
-        os.rmdir(path)
+        os.rmdir(path) or {
+            eprintln(err)
+            println('Terminating...')
+            exit(0)
+        }
         return true
     } else {
         return false
@@ -86,7 +95,11 @@ fn rm_test_execs(dir string) {
         base_exec_name = base_exec_name + '.exe'
     }
 
-    os.rm(base_exec_name)
+    os.rm(base_exec_name) or {
+        eprintln(err)
+        println('Terminating...')
+        exit(0)
+    }
 }
 
 fn is_url(a string) bool {

--- a/api/utils.v
+++ b/api/utils.v
@@ -2,7 +2,6 @@
 // https://github.com/vpkg-project/vpkg
 //
 // Copyright (c) 2020 vpkg developers
-// Copyright (c) 2021 Adam "islonely" Oates
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/vpkg.v
+++ b/vpkg.v
@@ -4,7 +4,7 @@ import api as vpkg
 import os
 
 fn main() {
-    args := os.args
+    args := os.args.clone()
     mut app := vpkg.new(os.getwd())
     
     app.run(args[1..])


### PR DESCRIPTION
A basic summary of what I did is: I added `or{...}` blocks to the code where required. And `lock` is apparently a keyword now, so I replaced every `lock Lockfile` with `lf Lockfile` in lockfile.v. In `struct Package {...}` I replaced `...string = ''` with `...string` because the type `string` now defaults to an empty string. And I think that's about it. You can look over the commits for anything I may have missed.